### PR TITLE
Adding inDirKeep method in run-context.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 coverage
+.idea

--- a/lib/index.js
+++ b/lib/index.js
@@ -96,6 +96,33 @@ exports.testDirectory = function (dir, cb) {
 };
 
 /**
+ * Cd into it testDirectory.
+ * Call given callback after entering the test directory.
+ * @param {String} dir - path to the test directory
+ * @param {Function} cb - callback executed after setting working directory to dir
+ * @example
+ * testDirectoryKeep(path.join(__dirname, './temp'), function () {
+ *   fs.writeFileSync('testfile', 'Roses are red.');
+ * });
+ */
+
+exports.testDirectoryKeep = function (dir, cb) {
+  if (!dir) {
+    throw new Error('Missing directory');
+  }
+
+  dir = path.resolve(dir);
+
+  // Make sure we're not deleting CWD by moving to top level folder. As we `cd` in the
+  // test dir after cleaning up, this shouldn't be perceivable.
+  process.chdir('/');
+
+  mkdirp.sync(dir);
+  process.chdir(dir);
+  cb();
+};
+
+/**
  * Answer prompt questions for the passed-in generator
  * @param {Generator} generator - a Yeoman generator
  * @param {Object} answers - an object where keys are the

--- a/lib/index.js
+++ b/lib/index.js
@@ -113,8 +113,6 @@ exports.testDirectoryKeep = function (dir, cb) {
 
   dir = path.resolve(dir);
 
-  // Make sure we're not deleting CWD by moving to top level folder. As we `cd` in the
-  // test dir after cleaning up, this shouldn't be perceivable.
   process.chdir('/');
 
   mkdirp.sync(dir);

--- a/lib/index.js
+++ b/lib/index.js
@@ -96,31 +96,6 @@ exports.testDirectory = function (dir, cb) {
 };
 
 /**
- * Cd into it testDirectory.
- * Call given callback after entering the test directory.
- * @param {String} dir - path to the test directory
- * @param {Function} cb - callback executed after setting working directory to dir
- * @example
- * testDirectoryKeep(path.join(__dirname, './temp'), function () {
- *   fs.writeFileSync('testfile', 'Roses are red.');
- * });
- */
-
-exports.testDirectoryKeep = function (dir, cb) {
-  if (!dir) {
-    throw new Error('Missing directory');
-  }
-
-  dir = path.resolve(dir);
-
-  process.chdir('/');
-
-  mkdirp.sync(dir);
-  process.chdir(dir);
-  cb();
-};
-
-/**
  * Answer prompt questions for the passed-in generator
  * @param {Generator} generator - a Yeoman generator
  * @param {Object} answers - an object where keys are the

--- a/lib/run-context.js
+++ b/lib/run-context.js
@@ -147,6 +147,26 @@ RunContext.prototype.inDir = function (dirPath, cb) {
 };
 
 /**
+ * Change directory into provided directory.
+ * @param  {String} dirPath - Directory path (relative to CWD). Prefer passing an absolute
+ *                            file path for predictable results
+ * @param {Function} [cb] - callback who'll receive the folder path as argument
+ * @return {this} run context instance
+ */
+
+RunContext.prototype.inDirKeep = function (dirPath, cb) {
+  this.inDirSet = true;
+  this.targetDirectory = dirPath;
+  var release = this.async();
+  var callBackThenRelease = _.flowRight(
+    release,
+    (cb || _.noop).bind(this, path.resolve(dirPath))
+  );
+  helpers.testDirectoryKeep(dirPath, callBackThenRelease);
+  return this;
+};
+
+/**
  * Cleanup a temporary directy and change the CWD into it
  *
  * This method is called automatically when creating a RunContext. Only use it if you need

--- a/lib/run-context.js
+++ b/lib/run-context.js
@@ -150,21 +150,11 @@ RunContext.prototype.inDir = function (dirPath, cb) {
  * Change directory into provided directory.
  * @param  {String} dirPath - Directory path (relative to CWD). Prefer passing an absolute
  *                            file path for predictable results
- * @param {Function} [cb] - callback who'll receive the folder path as argument
  * @return {this} run context instance
  */
-
-RunContext.prototype.inDirKeep = function (dirPath, cb) {
+RunContext.prototype.cd = function (dirPath) {
   this.inDirSet = true;
   this.targetDirectory = dirPath;
-  var release = this.async();
-  var callBackThenRelease = _.flowRight(
-    release,
-    (cb || _.noop).bind(this, path.resolve(dirPath))
-  );
-
-  callBackThenRelease();
-
   return this;
 };
 

--- a/lib/run-context.js
+++ b/lib/run-context.js
@@ -163,10 +163,6 @@ RunContext.prototype.inDirKeep = function (dirPath, cb) {
     (cb || _.noop).bind(this, path.resolve(dirPath))
   );
   
-  if (!dir) {		
-    throw new Error('Missing directory');		
-  }
-  
   callBackThenRelease();
   
   return this;

--- a/lib/run-context.js
+++ b/lib/run-context.js
@@ -162,7 +162,13 @@ RunContext.prototype.inDirKeep = function (dirPath, cb) {
     release,
     (cb || _.noop).bind(this, path.resolve(dirPath))
   );
-  helpers.testDirectoryKeep(dirPath, callBackThenRelease);
+  
+  if (!dir) {		
+    throw new Error('Missing directory');		
+  }
+  
+  callBackThenRelease();
+  
   return this;
 };
 

--- a/lib/run-context.js
+++ b/lib/run-context.js
@@ -162,9 +162,9 @@ RunContext.prototype.inDirKeep = function (dirPath, cb) {
     release,
     (cb || _.noop).bind(this, path.resolve(dirPath))
   );
-  
+
   callBackThenRelease();
-  
+
   return this;
 };
 

--- a/test/run-context.js
+++ b/test/run-context.js
@@ -279,14 +279,7 @@ describe('RunContext', function () {
       process.chdir(__dirname);
       this.tmp = tmpdir;
     });
-
-    it('call helpers.testDirectoryKeep()', function () {
-      sinon.spy(helpers, 'testDirectoryKeep');
-      this.ctx.inDirKeep(this.tmp);
-      assert(helpers.testDirectoryKeep.calledOnce);
-      helpers.testDirectoryKeep.restore();
-    });
-
+    
     it('do not call helpers.testDirectory()', function () {
       sinon.spy(helpers, 'testDirectory');
       this.ctx.inDirKeep(this.tmp);

--- a/test/run-context.js
+++ b/test/run-context.js
@@ -279,7 +279,7 @@ describe('RunContext', function () {
       process.chdir(__dirname);
       this.tmp = tmpdir;
     });
-    
+
     it('do not call helpers.testDirectory()', function () {
       sinon.spy(helpers, 'testDirectory');
       this.ctx.inDirKeep(this.tmp);

--- a/test/run-context.js
+++ b/test/run-context.js
@@ -274,7 +274,7 @@ describe('RunContext', function () {
     });
   });
 
-  describe('#inDirKeep()', function () {
+  describe('#cd()', function () {
     beforeEach(function () {
       process.chdir(__dirname);
       this.tmp = tmpdir;
@@ -282,44 +282,23 @@ describe('RunContext', function () {
 
     it('do not call helpers.testDirectory()', function () {
       sinon.spy(helpers, 'testDirectory');
-      this.ctx.inDirKeep(this.tmp);
+      this.ctx.cd(this.tmp);
       assert(!helpers.testDirectory.calledOnce);
       helpers.testDirectory.restore();
     });
 
     it('is chainable', function () {
-      assert.equal(this.ctx.inDir(this.tmp), this.ctx);
+      assert.equal(this.ctx.cd(this.tmp), this.ctx);
     });
 
-    it('accepts optional `cb` to be invoked with resolved `dir`', function (done) {
-      var ctx = new RunContext(this.Dummy);
-      var cb = sinon.spy(function () {
-        sinon.assert.calledOnce(cb);
-        sinon.assert.calledOn(cb, ctx);
-        sinon.assert.calledWith(cb, path.resolve(this.tmp));
-      }.bind(this));
-
-      ctx.inDirKeep(this.tmp, cb).on('end', done);
+    it('should set inDirSet & targetDirectory', function () {
+      assert(!this.ctx.inDirSet);
+      assert(!this.ctx.targetDirectory);
+      this.ctx.cd(this.tmp);
+      assert.equal(this.ctx.inDirSet, true);
+      assert.equal(this.ctx.targetDirectory, this.tmp);
     });
 
-    it('optional `cb` can use `this.async()` to delay execution', function (done) {
-      var ctx = new RunContext(this.Dummy);
-      var delayed = false;
-
-      ctx
-        .inDirKeep(this.tmp, function () {
-          var release = this.async();
-
-          setTimeout(function () {
-            delayed = true;
-            release();
-          }, 1);
-        })
-        .on('ready', function () {
-          assert(delayed);
-        })
-        .on('end', done);
-    });
   });
 
   describe('#inTmpDir', function () {


### PR DESCRIPTION
I added `inDirKeep` method in order to preserve files after `generators/app/index.js` execution.

With the method `inDirKeep` you can speed up or eliminate manual testing while developing on generator so that developers that build up generator would not repeat over and over again this code:

```
yo generatorName
//Prompting

yo generatorName:subgenName
//Prompting

...

yo generatorName:subgenName
//Prompting

rm -rf *
rm -rf .* //Not .yo-rc.json
```

Problem is that subgenerators can be dependant to files generated with `generators/app/index.js`, so the subgenerator must run in the same directory. With the current methods you can't do this because `inDir` method will call `rm -rf` to directory where `.../app/index.js` was called.