### PR TITLE
Hotfix/1.5.0

### DIFF
--- a/lib/run-context.js
+++ b/lib/run-context.js
@@ -11,8 +11,6 @@ var rimraf = require('rimraf');
 var EventEmitter = require('events').EventEmitter;
 var helpers = require('./');
 var TestAdapter = require('./adapter').TestAdapter;
-var mkdirp = require('mkdirp');
-
 
 /**
  * This class provide a run context object to façade the complexity involved in setting
@@ -158,8 +156,11 @@ RunContext.prototype.inDirKeep = function (dirPath) {
   this.inDirSet = true;
   this.targetDirectory = dirPath;
   dirPath = path.resolve(dirPath);
-  mkdirp.sync(dirPath);
-  process.chdir(dirPath);
+  try {
+    process.chdir(dirPath);
+  } catch (err) {
+    throw new Error(err.message + ' ' + dirPath);
+  }
   return this;
 };
 

--- a/lib/run-context.js
+++ b/lib/run-context.js
@@ -11,6 +11,8 @@ var rimraf = require('rimraf');
 var EventEmitter = require('events').EventEmitter;
 var helpers = require('./');
 var TestAdapter = require('./adapter').TestAdapter;
+var mkdirp = require('mkdirp');
+
 
 /**
  * This class provide a run context object to façade the complexity involved in setting
@@ -147,14 +149,17 @@ RunContext.prototype.inDir = function (dirPath, cb) {
 };
 
 /**
- * Change directory into provided directory.
+ * Change directory without deleting directory content.
  * @param  {String} dirPath - Directory path (relative to CWD). Prefer passing an absolute
  *                            file path for predictable results
  * @return {this} run context instance
  */
-RunContext.prototype.cd = function (dirPath) {
+RunContext.prototype.inDirKeep = function (dirPath) {
   this.inDirSet = true;
   this.targetDirectory = dirPath;
+  dirPath = path.resolve(dirPath);
+  mkdirp.sync(dirPath);
+  process.chdir(dirPath);
   return this;
 };
 

--- a/lib/run-context.js
+++ b/lib/run-context.js
@@ -152,7 +152,7 @@ RunContext.prototype.inDir = function (dirPath, cb) {
  *                            file path for predictable results
  * @return {this} run context instance
  */
-RunContext.prototype.inDirKeep = function (dirPath) {
+RunContext.prototype.cd = function (dirPath) {
   this.inDirSet = true;
   this.targetDirectory = dirPath;
   dirPath = path.resolve(dirPath);

--- a/test/run-context.js
+++ b/test/run-context.js
@@ -300,9 +300,9 @@ describe('RunContext', function () {
       assert.equal(this.ctx.targetDirectory, this.tmp);
     });
 
-    it('should mkdir and cd into created directory',function(){
-      sinon.spy(mkdirp,'sync');
-      sinon.spy(process,'chdir');
+    it('should mkdir and cd into created directory', function () {
+      sinon.spy(mkdirp, 'sync');
+      sinon.spy(process, 'chdir');
       this.ctx.inDirKeep(this.tmp);
       assert(mkdirp.sync.calledWith(this.tmp));
       assert(process.chdir.calledWith(this.tmp));

--- a/test/run-context.js
+++ b/test/run-context.js
@@ -279,6 +279,7 @@ describe('RunContext', function () {
     beforeEach(function () {
       process.chdir(__dirname);
       this.tmp = tmpdir;
+      mkdirp.sync(tmpdir);
     });
 
     it('do not call helpers.testDirectory()', function () {
@@ -300,14 +301,20 @@ describe('RunContext', function () {
       assert.equal(this.ctx.targetDirectory, this.tmp);
     });
 
-    it('should mkdir and cd into created directory', function () {
-      sinon.spy(mkdirp, 'sync');
+    it('should cd into created directory', function () {
       sinon.spy(process, 'chdir');
       this.ctx.inDirKeep(this.tmp);
-      assert(mkdirp.sync.calledWith(this.tmp));
       assert(process.chdir.calledWith(this.tmp));
-      mkdirp.sync.restore();
       process.chdir.restore();
+    });
+
+    it('should throw error if directory do not exist', function () {
+      try {
+        this.ctx.inDirKeep(path.join(this.tmp, 'NOT_EXIST'));
+        assert.fail();
+      } catch (err) {
+        assert(err.message.indexOf(this.tmp) !== -1);
+      }
     });
 
   });

--- a/test/run-context.js
+++ b/test/run-context.js
@@ -9,6 +9,7 @@ var RunContext = require('../lib/run-context');
 var generators = require('yeoman-generator');
 var tmpdir = path.join(os.tmpdir(), 'yeoman-run-context');
 var helpers = require('../lib');
+var mkdirp = require('mkdirp');
 
 describe('RunContext', function () {
   beforeEach(function () {
@@ -274,7 +275,7 @@ describe('RunContext', function () {
     });
   });
 
-  describe('#cd()', function () {
+  describe('#inDirKeep()', function () {
     beforeEach(function () {
       process.chdir(__dirname);
       this.tmp = tmpdir;
@@ -282,21 +283,31 @@ describe('RunContext', function () {
 
     it('do not call helpers.testDirectory()', function () {
       sinon.spy(helpers, 'testDirectory');
-      this.ctx.cd(this.tmp);
+      this.ctx.inDirKeep(this.tmp);
       assert(!helpers.testDirectory.calledOnce);
       helpers.testDirectory.restore();
     });
 
     it('is chainable', function () {
-      assert.equal(this.ctx.cd(this.tmp), this.ctx);
+      assert.equal(this.ctx.inDirKeep(this.tmp), this.ctx);
     });
 
     it('should set inDirSet & targetDirectory', function () {
       assert(!this.ctx.inDirSet);
       assert(!this.ctx.targetDirectory);
-      this.ctx.cd(this.tmp);
+      this.ctx.inDirKeep(this.tmp);
       assert.equal(this.ctx.inDirSet, true);
       assert.equal(this.ctx.targetDirectory, this.tmp);
+    });
+
+    it('should mkdir and cd into created directory',function(){
+      sinon.spy(mkdirp,'sync');
+      sinon.spy(process,'chdir');
+      this.ctx.inDirKeep(this.tmp);
+      assert(mkdirp.sync.calledWith(this.tmp));
+      assert(process.chdir.calledWith(this.tmp));
+      mkdirp.sync.restore();
+      process.chdir.restore();
     });
 
   });

--- a/test/run-context.js
+++ b/test/run-context.js
@@ -275,7 +275,7 @@ describe('RunContext', function () {
     });
   });
 
-  describe('#inDirKeep()', function () {
+  describe('#cd()', function () {
     beforeEach(function () {
       process.chdir(__dirname);
       this.tmp = tmpdir;
@@ -284,33 +284,33 @@ describe('RunContext', function () {
 
     it('do not call helpers.testDirectory()', function () {
       sinon.spy(helpers, 'testDirectory');
-      this.ctx.inDirKeep(this.tmp);
+      this.ctx.cd(this.tmp);
       assert(!helpers.testDirectory.calledOnce);
       helpers.testDirectory.restore();
     });
 
     it('is chainable', function () {
-      assert.equal(this.ctx.inDirKeep(this.tmp), this.ctx);
+      assert.equal(this.ctx.cd(this.tmp), this.ctx);
     });
 
     it('should set inDirSet & targetDirectory', function () {
       assert(!this.ctx.inDirSet);
       assert(!this.ctx.targetDirectory);
-      this.ctx.inDirKeep(this.tmp);
+      this.ctx.cd(this.tmp);
       assert.equal(this.ctx.inDirSet, true);
       assert.equal(this.ctx.targetDirectory, this.tmp);
     });
 
     it('should cd into created directory', function () {
       sinon.spy(process, 'chdir');
-      this.ctx.inDirKeep(this.tmp);
+      this.ctx.cd(this.tmp);
       assert(process.chdir.calledWith(this.tmp));
       process.chdir.restore();
     });
 
     it('should throw error if directory do not exist', function () {
       try {
-        this.ctx.inDirKeep(path.join(this.tmp, 'NOT_EXIST'));
+        this.ctx.cd(path.join(this.tmp, 'NOT_EXIST'));
         assert.fail();
       } catch (err) {
         assert(err.message.indexOf(this.tmp) !== -1);


### PR DESCRIPTION
While making test for my own generator I discover issue with yeoman version `1.5.0` which does not create and cd to directory when using run-context method 'cd'. This is fixed now. However the name 'cd' is  somehow bad because it should tell the end user that this method will create directory and not joust 'cd' in to it. So 'inDirKeep' seems to be valid option here.

On linux if you would cd to the directory that don't exist will throw an error:
```bash
> cd dontExist
cd: no such file or directory: dontExist
```