### PR TITLE
Catch errors from yeoman-generator

### DIFF
--- a/lib/run-context.js
+++ b/lib/run-context.js
@@ -112,7 +112,7 @@ RunContext.prototype._run = function () {
   }.bind(this));
 
   this.emit('ready', this.generator);
-  this.generator.run();
+  this.generator.run().catch(err => this.emit('error', err));
 };
 
 /**


### PR DESCRIPTION
We probably should catch errors from `run` here.

Error example:
```
AssertionError [ERR_ASSERTION]: This Generator is empty. Add at least one method for it to run.
```