### PR TITLE
Add catch error test case.

### DIFF
--- a/lib/run-context.js
+++ b/lib/run-context.js
@@ -21,7 +21,8 @@ var TestAdapter = require('./adapter').TestAdapter;
  *                                       'gen:test' in all cases
  * @param {Object} [settings]
  * @param {Boolean} [settings.tmpdir=true] - Automatically run this generator in a tmp dir
- * @param {Boolean} [settings.compatibility=false] - Run with yeoman-test 1.x compatibility
+ * @param {Boolean} [settings.catchGeneratorError=false] - In some corn cases a error can be thrown but not
+ *                                                         emitted, set true to catch it.
  * @param {String} [settings.resolved] - File path to the generator (only used if Generator is a constructor)
  * @param {String} [settings.namespace='gen:test'] - Namespace (only used if Generator is a constructor)
  * @return {this}
@@ -38,7 +39,7 @@ function RunContext(Generator, settings) {
   this.dependencies = [];
   this.Generator = Generator;
   this.settings = _.extend(
-    { tmpdir: true, namespace: 'gen:test', compatibility: false },
+    { tmpdir: true, namespace: 'gen:test', catchGeneratorError: false },
     settings
   );
   this.withOptions({
@@ -128,7 +129,7 @@ RunContext.prototype._run = function() {
   this.emit('ready', this.generator);
 
   const generatorPromise = this.generator.run();
-  if (!this.settings.compatibility) {
+  if (this.settings.catchGeneratorError) {
     generatorPromise.catch(err => this.emit('error', err));
   }
 };

--- a/lib/run-context.js
+++ b/lib/run-context.js
@@ -21,7 +21,7 @@ var TestAdapter = require('./adapter').TestAdapter;
  *                                       'gen:test' in all cases
  * @param {Object} [settings]
  * @param {Boolean} [settings.tmpdir=true] - Automatically run this generator in a tmp dir
- * @param {Boolean} [settings.catchGeneratorError=false] - In some corn cases a error can be thrown but not
+ * @param {Boolean} [settings.catchGeneratorError=false] - In some corner cases an error can be thrown but not
  *                                                         emitted, set true to catch it.
  * @param {String} [settings.resolved] - File path to the generator (only used if Generator is a constructor)
  * @param {String} [settings.namespace='gen:test'] - Namespace (only used if Generator is a constructor)

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -224,7 +224,7 @@ describe('yeoman-test', function() {
         });
     });
 
-    // This is a workaround for corn case were an error is not correctly emitted
+    // This is a workaround for corner case were an error is not correctly emitted
     // See https://github.com/yeoman/generator/pull/1155
     it('catch run errors', function(done) {
       helpers

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -181,5 +181,57 @@ describe('yeoman-test', function() {
       var runContext = helpers.run(helpers.createDummyGenerator(), { foo: 1 });
       assert.equal(runContext.settings.foo, 1);
     });
+
+    it('catch env errors', function(done) {
+      helpers
+        .run(
+          class extends helpers.createDummyGenerator() {
+            throws() {
+              this.env.emit('error', new Error());
+            }
+          }
+        )
+        .on('error', _ => {
+          done();
+        });
+    });
+
+    it('catch generator emitted errors', function(done) {
+      helpers
+        .run(
+          class extends helpers.createDummyGenerator() {
+            throws() {
+              this.emit('error', new Error());
+            }
+          }
+        )
+        .on('error', _ => {
+          done();
+        });
+    });
+
+    it('catch generator thrown errors', function(done) {
+      helpers
+        .run(
+          class extends helpers.createDummyGenerator() {
+            throws() {
+              throw new Error();
+            }
+          }
+        )
+        .on('error', _ => {
+          done();
+        });
+    });
+
+    // This is a workaround for corn case were an error is not correctly emitted
+    // See https://github.com/yeoman/generator/pull/1155
+    it('catch run errors', function(done) {
+      helpers
+        .run(class extends Generator {}, { catchGeneratorError: true })
+        .on('error', _ => {
+          done();
+        });
+    });
   });
 });


### PR DESCRIPTION
@SBoudrias I'm trying to understand https://github.com/yeoman/yeoman-test/pull/47.
When running this.env.error, errors are been catch twice. Looks like a bug to me.
Should I do something different?