### PR TITLE
Fix Node 16 deprecation

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -86,7 +86,12 @@ YeomanTest.prototype.testDirectory = function (dir, cb) {
 
   try {
     if (fs.existsSync(dir)) {
-      fs.rmdirSync(dir, {recursive: true});
+      const args = [dir, {recursive: true}];
+      if (fs.rmSync) {
+        fs.rmSync(...args);
+      } else {
+        fs.rmdirSync(...args);
+      }
     }
 
     fs.mkdirSync(dir, {recursive: true});

--- a/lib/index.js
+++ b/lib/index.js
@@ -86,12 +86,8 @@ YeomanTest.prototype.testDirectory = function (dir, cb) {
 
   try {
     if (fs.existsSync(dir)) {
-      const args = [dir, {recursive: true}];
-      if (fs.rmSync) {
-        fs.rmSync(...args);
-      } else {
-        fs.rmdirSync(...args);
-      }
+      const {rmdirSync, rmSync = rmdirSync} = fs;
+      rmSync(dir, {recursive: true});
     }
 
     fs.mkdirSync(dir, {recursive: true});

--- a/lib/run-context.js
+++ b/lib/run-context.js
@@ -423,7 +423,12 @@ RunContext.prototype.cleanTestDirectory = function (force = false) {
   }
 
   if (this.targetDirectory && fs.existsSync(this.targetDirectory)) {
-    fs.rmdirSync(this.targetDirectory, {recursive: true});
+    const args = [this.targetDirectory, {recursive: true}];
+    if (fs.rmSync) {
+      fs.rmSync(...args);
+    } else {
+      fs.rmdirSync(...args);
+    }
   }
 };
 

--- a/lib/run-context.js
+++ b/lib/run-context.js
@@ -423,12 +423,8 @@ RunContext.prototype.cleanTestDirectory = function (force = false) {
   }
 
   if (this.targetDirectory && fs.existsSync(this.targetDirectory)) {
-    const args = [this.targetDirectory, {recursive: true}];
-    if (fs.rmSync) {
-      fs.rmSync(...args);
-    } else {
-      fs.rmdirSync(...args);
-    }
+    const {rmdirSync, rmSync = rmdirSync} = fs;
+    rmSync(this.targetDirectory, {recursive: true});
   }
 };
 

--- a/lib/run-result.js
+++ b/lib/run-result.js
@@ -124,7 +124,13 @@ class RunResult {
    */
   cleanup() {
     process.chdir(this.oldCwd);
-    fs.rmdirSync(this.cwd, {recursive: true});
+    const args = [this.cwd, {recursive: true}];
+    if (fs.rmSync) {
+      fs.rmSync(...args);
+    } else {
+      fs.rmdirSync(...args);
+    }
+
     return this;
   }
 

--- a/lib/run-result.js
+++ b/lib/run-result.js
@@ -124,13 +124,8 @@ class RunResult {
    */
   cleanup() {
     process.chdir(this.oldCwd);
-    const args = [this.cwd, {recursive: true}];
-    if (fs.rmSync) {
-      fs.rmSync(...args);
-    } else {
-      fs.rmdirSync(...args);
-    }
-
+    const {rmdirSync, rmSync = rmdirSync} = fs;
+    rmSync(this.cwd, {recursive: true});
     return this;
   }
 


### PR DESCRIPTION
Node 16 shows following deprecation:

```sh
(node:81356) [DEP0147] DeprecationWarning: In future versions of Node.js, fs.rmdir(path, { recursive: true }) will be removed. Use fs.rm(path, { recursive: true }) instead
(Use `node --trace-deprecation ...` to show where the warning was created)
```

Since `fs.rmSync` was added in v14.14.0, and `yeoman-test` supports Node 12, calls to `fs.rmSync` are conditionally checked.