### PR TITLE
Improve typing of RunResult

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -22,10 +22,10 @@ export type Dependency = string | Parameters<Environment['registerStub']> | Para
 
 type GeneratorNew<GenParameter extends YeomanGenerator = YeomanGenerator> = new (
   ...args: ConstructorParameters<typeof YeomanGenerator<GenParameter['options']>>
-) => YeomanGenerator<GenParameter['options']>;
+) => GenParameter;
 type GeneratorBuilder<GenParameter extends YeomanGenerator = YeomanGenerator> = (
   ...args: ConstructorParameters<typeof YeomanGenerator<GenParameter['options']>>
-) => YeomanGenerator<GenParameter['options']>;
+) => GenParameter;
 
 export type GeneratorConstructor<GenParameter extends YeomanGenerator = YeomanGenerator> =
   | GeneratorNew<GenParameter>
@@ -305,7 +305,7 @@ export class YeomanTest {
    */
 
   run<GeneratorType extends YeomanGenerator = YeomanGenerator>(
-    GeneratorOrNamespace: string | GeneratorConstructor,
+    GeneratorOrNamespace: string | GeneratorConstructor<GeneratorType>,
     settings?: RunContextSettings,
     envOptions?: Options,
   ): RunContext<GeneratorType> {
@@ -332,7 +332,7 @@ export class YeomanTest {
    */
 
   create<GeneratorType extends YeomanGenerator = YeomanGenerator>(
-    GeneratorOrNamespace: string | GeneratorConstructor,
+    GeneratorOrNamespace: string | GeneratorConstructor<GeneratorType>,
     settings?: RunContextSettings,
     envOptions?: Options,
   ) {

--- a/src/run-context.ts
+++ b/src/run-context.ts
@@ -70,7 +70,7 @@ export class RunContextBase<GeneratorType extends Generator = Generator> extends
   private readonly onEnvironmentCallbacks: Array<(this: this, env: Environment) => any> = [];
 
   private readonly inDirCallbacks: any[] = [];
-  private readonly Generator: string | GeneratorConstructor | typeof Generator;
+  private readonly Generator: string | GeneratorConstructor<GeneratorType> | typeof Generator;
   private readonly helpers: YeomanTest;
   private readonly temporaryDir = path.join(tempDirectory, crypto.randomBytes(20).toString('hex'));
 
@@ -94,7 +94,7 @@ export class RunContextBase<GeneratorType extends Generator = Generator> extends
    */
 
   constructor(
-    generatorType: string | GeneratorConstructor | typeof Generator,
+    generatorType: string | GeneratorConstructor<GeneratorType> | typeof Generator,
     settings?: RunContextSettings,
     envOptions: Options = {},
     helpers = defaultHelpers,

--- a/src/run-result.ts
+++ b/src/run-result.ts
@@ -66,7 +66,7 @@ export type RunResultOptions<GeneratorType extends Generator> = {
  * This class provides utilities for testing generated content.
  */
 
-export default class RunResult<GeneratorType extends Generator> {
+export default class RunResult<GeneratorType extends Generator = Generator> {
   env: any;
   generator: GeneratorType;
   cwd: string;


### PR DESCRIPTION
This PR adds 2 changes:
 - Add default for generator type in RunResult: this allows typing the result as juste `RunResult` in places where we don't care of the type of the generator.
- Improve typing in helpers to make typescript better at infering the generator type: when doing `hepers.create(MyGenerator)`, typescript will now correctly infer the result as `RunResult<MyGenerator>`