### PR TITLE
fix mem-fs reuse when creating a new context from result.

### DIFF
--- a/src/run-result.ts
+++ b/src/run-result.ts
@@ -102,10 +102,11 @@ export default class RunResult<GeneratorType extends Generator = Generator> {
         ...this.options.settings,
         cwd: this.cwd,
         oldCwd: this.oldCwd,
+        memFs: this.memFs,
         ...settings,
         autoCleanup: false,
       },
-      { ...this.options.envOptions, memFs: this.memFs, ...envOptions },
+      { ...this.options.envOptions, ...envOptions },
     );
   }
 

--- a/test/run-context-environment.spec.ts
+++ b/test/run-context-environment.spec.ts
@@ -68,6 +68,12 @@ describe('RunContext running environment', function () {
       });
     });
 
+    it('forwards the mem-fs to the environment', () => {
+      return ctx.run().then(() => {
+        assert.equal(ctx.memFs, ctx.env.sharedFs);
+      });
+    });
+
     it('passes newErrorHandler to the environment', () => {
       return ctx.run().then(() => {
         assert(ctx.env.options.newErrorHandler);

--- a/test/run-result.spec.ts
+++ b/test/run-result.spec.ts
@@ -234,8 +234,8 @@ describe('run-result', () => {
     it('forwards oldCwd from the original RunResult', () => {
       assert.equal(runContext.oldCwd, oldCwd);
     });
-    it('forwards memFs from the original RunResult to new envOptions', () => {
-      assert.equal(runContext.envOptions.memFs, memFs);
+    it('forwards memFs from the original RunResult to new RunContext', () => {
+      assert.equal(runContext.memFs, memFs);
     });
     it('prefers settings passed to the method', () => {
       assert.equal(runContext.settings.overrided, 'newOverrided');


### PR DESCRIPTION
- add option to don't reset mem-fs files.
- execute commit before creating the environment.