### PR TITLE
feat: allow loading using require()

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -8,5 +8,6 @@ export default config(...configs, {
     'unicorn/no-thenable': 'off',
     'unicorn/prefer-event-target': 'off',
     'unicorn/no-object-as-default-parameter': 'off',
+    'unicorn/prefer-top-level-await': 'off',
   },
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "lodash-es": "^4.17.21",
         "mem-fs-editor": "^11.1.1",
         "signal-exit": "^4.1.0",
-        "temp-dir": "^3.0.0",
         "type-fest": "^4.25.0"
       },
       "devDependencies": {
@@ -10002,14 +10001,6 @@
       "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
       "dependencies": {
         "streamx": "^2.12.5"
-      }
-    },
-    "node_modules/temp-dir": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-3.0.0.tgz",
-      "integrity": "sha512-nHc6S/bwIilKHNRgK/3jlhDoIHcp45YgyiwcAk46Tr0LfEqGBVpmiAyuiuxeVE44m3mXnEeVhaipLOEWmH+Njw==",
-      "engines": {
-        "node": ">=14.16"
       }
     },
     "node_modules/text-table": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     },
     ".": {
       "types": "./dist/index.d.ts",
-      "default": "./dist/index.js"
+      "require": "./dist/index.js",
+      "default": "./dist/import.js"
     }
   },
   "main": "./dist/index.js",

--- a/package.json
+++ b/package.json
@@ -46,14 +46,13 @@
     "lodash-es": "^4.17.21",
     "mem-fs-editor": "^11.1.1",
     "signal-exit": "^4.1.0",
-    "temp-dir": "^3.0.0",
     "type-fest": "^4.25.0"
   },
   "devDependencies": {
-    "@yeoman/adapter": "^2.0.0",
     "@types/lodash-es": "^4.17.12",
     "@types/node": ">=18.19.46",
     "@vitest/coverage-v8": "^3.0.2",
+    "@yeoman/adapter": "^2.0.0",
     "@yeoman/eslint": "0.2.0",
     "coveralls": "^3.1.1",
     "husky": "^9.1.5",

--- a/src/import.ts
+++ b/src/import.ts
@@ -1,0 +1,13 @@
+import { setDefaultDummyParentClass } from './helpers.js';
+
+let GeneratorImplementation;
+try {
+  const GeneratorImport = await import('yeoman-generator');
+  GeneratorImplementation = GeneratorImport.default ?? GeneratorImport;
+  setDefaultDummyParentClass(GeneratorImplementation);
+} catch {
+  // ignore
+}
+
+export * from './index.js';
+export { default } from './index.js';

--- a/src/run-context.ts
+++ b/src/run-context.ts
@@ -1,14 +1,14 @@
 import crypto from 'node:crypto';
-import { existsSync, rmSync } from 'node:fs';
+import { existsSync, realpathSync, rmSync } from 'node:fs';
 import path, { isAbsolute, join as pathJoin, resolve } from 'node:path';
 import assert from 'node:assert';
 import { EventEmitter } from 'node:events';
+import { tmpdir } from 'node:os';
 import process from 'node:process';
 import { mock } from 'node:test';
 import { camelCase, kebabCase, merge as lodashMerge, set as lodashSet } from 'lodash-es';
 import { resetFileCommitStates } from 'mem-fs-editor/state';
 import { type Store, create as createMemFs } from 'mem-fs';
-import tempDirectory from 'temp-dir';
 import type {
   BaseEnvironmentOptions,
   BaseGenerator,
@@ -23,6 +23,8 @@ import RunResult, { type RunResultOptions } from './run-result.js';
 import defaultHelpers, { type CreateEnv as CreateEnvironment, type Dependency, type YeomanTest } from './helpers.js';
 import { type AskedQuestions, type DummyPromptCallback, type DummyPromptOptions, type TestAdapterOptions } from './adapter.js';
 import testContext from './test-context.js';
+
+const tempDirectory = realpathSync(tmpdir());
 
 /**
  * Provides settings for creating a `RunContext`.

--- a/test/helpers.spec.ts
+++ b/test/helpers.spec.ts
@@ -10,9 +10,11 @@ import Generator from 'yeoman-generator';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import type Environment from 'yeoman-environment';
 import { createEnv as createEnvironment } from '../src/default-environment.js';
-import helpers from '../src/helpers.js';
+import helpers from '../src/import.js';
 import { TestAdapter } from '../src/adapter.js';
 import RunContext from '../src/run-context.js';
+
+const [major, minor] = process.versions.node.split('.').map(Number);
 
 /* Remove argument from promisify return */
 const promisify = function_ => () => promisify_(function_)();
@@ -31,8 +33,8 @@ describe('yeoman-test', () => {
     StubGenerator = class extends Generator {};
   });
 
-  it('yeoman-test should allow to be required', () => {
-    createRequire(import.meta.url)('../');
+  it.skipIf(major < 22 || (major == 22 && minor < 12))('yeoman-test should allow to be required', () => {
+    require('../').default.createMockedGenerator();
   });
 
   describe('.createGenerator()', () => {

--- a/test/helpers.spec.ts
+++ b/test/helpers.spec.ts
@@ -31,6 +31,10 @@ describe('yeoman-test', () => {
     StubGenerator = class extends Generator {};
   });
 
+  it('yeoman-test should allow to be required', () => {
+    createRequire(import.meta.url)('../');
+  });
+
   describe('.createGenerator()', () => {
     it('create a new generator', async () => {
       const generator = await helpers.createGenerator('unicorn:app', {

--- a/test/run-context-environment.spec.ts
+++ b/test/run-context-environment.spec.ts
@@ -6,7 +6,7 @@ import { createRequire } from 'node:module';
 import { mock } from 'node:test';
 import { type LookupOptions } from '@yeoman/types';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, it } from 'vitest';
-import helpers from '../src/helpers.js';
+import helpers from '../src/import.js';
 import RunContext from '../src/run-context.js';
 import RunResult from '../src/run-result.js';
 import SimpleApp from './fixtures/generator-simple/app/index.js';

--- a/test/run-context.spec.ts
+++ b/test/run-context.spec.ts
@@ -10,7 +10,7 @@ import { promisify as promisify_ } from 'node:util';
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import Generator from 'yeoman-generator';
 import { RunContextBase as RunContext } from '../src/run-context.js';
-import helpers from '../src/helpers.js';
+import helpers from '../src/import.js';
 import { BaseEnvironmentOptions } from '@yeoman/types';
 
 const tempDirectory = realpathSync(os.tmpdir());

--- a/test/run-context.spec.ts
+++ b/test/run-context.spec.ts
@@ -1,17 +1,19 @@
-import fs from 'node:fs';
+import fs, { realpathSync } from 'node:fs';
 import path, { dirname } from 'node:path';
 import assert from 'node:assert';
 import { fileURLToPath } from 'node:url';
 import process from 'node:process';
 import { createRequire } from 'node:module';
+import os from 'node:os';
 import { mock } from 'node:test';
 import { promisify as promisify_ } from 'node:util';
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import Generator from 'yeoman-generator';
-import tempDirectory from 'temp-dir';
 import { RunContextBase as RunContext } from '../src/run-context.js';
 import helpers from '../src/helpers.js';
 import { BaseEnvironmentOptions } from '@yeoman/types';
+
+const tempDirectory = realpathSync(os.tmpdir());
 
 /* Remove argument from promisify return */
 const promisify = function_ => () => promisify_(function_)();

--- a/test/run-result.spec.ts
+++ b/test/run-result.spec.ts
@@ -8,7 +8,7 @@ import { create as createMemFsEditor } from 'mem-fs-editor';
 import { afterEach, beforeAll, beforeEach, describe, it } from 'vitest';
 import RunContext from '../src/run-context.js';
 import RunResult from '../src/run-result.js';
-import helpers from '../src/helpers.js';
+import helpers from '../src/import.js';
 import testContext, { result } from '../src/test-context.js';
 
 describe('run-result', () => {


### PR DESCRIPTION
<!--
Allo' allo'! 
Thanks for taking the time to submit a pull request ❤

Please make sure you read and fulfill our pull request guidelines:
https://github.com/yeoman/.github/blob/master/.github/contributing.md

Additional useful information is placed on the Yeoman Website:
http://yeoman.io/contributing/pull-request.html
-->

## Purpose of this pull request? 

- [ ] Documentation update
- [ ] Bug fix 
- [x] Enhancement
- [ ] Other, please explain:

## What changes did you make?

[ESM require()](https://nodejs.org/api/modules.html#loading-ecmascript-modules-using-require) is not compatible with top level await, so we need to extract top level await into another export to make the require export compatible with require().
<!-- Give an overview -->

## Is there anything you'd like reviewers to focus on?

<!-- Just in case -->